### PR TITLE
[FEATURE] TYPO3 CMS v10 compatibility + resolve ../ in VERSION path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,7 @@ jobs:
       env: TYPO3_VERSION=9.5.7
     - stage: test
       php: 7.2
+      env: TYPO3_VERSION=10.4.12
+    - stage: test
+      php: 7.2
       env: TYPO3_VERSION=dev-master

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -20,6 +20,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 /**
  * Class ExtensionConfiguration
@@ -116,12 +117,7 @@ final class ExtensionConfiguration implements SingletonInterface
      */
     private function getExtensionConfigurationFromGlobals(): array
     {
-        $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['project_version'];
-
-        if (is_string($configuration)) {
-            $configuration = @unserialize($configuration);
-        }
-
+        $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['project_version'];
         return $configuration ?? [];
     }
 

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -16,6 +16,7 @@ namespace KamiYang\ProjectVersion\Configuration;
  */
 
 use KamiYang\ProjectVersion\Enumeration\ProjectVersionModeEnumeration;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
@@ -64,7 +65,8 @@ final class ExtensionConfiguration implements SingletonInterface
      */
     public static function getAbsVersionFilePath(): string
     {
-        return GeneralUtility::getFileAbsFileName(self::getVersionFilePath());
+        $path = GeneralUtility::resolveBackPath(Environment::getPublicPath() . '/' . self::getVersionFilePath());
+        return GeneralUtility::getFileAbsFileName($path);
     }
 
     /**

--- a/Classes/Facade/SystemEnvironmentBuilderFacade.php
+++ b/Classes/Facade/SystemEnvironmentBuilderFacade.php
@@ -15,7 +15,7 @@ namespace KamiYang\ProjectVersion\Facade;
  * LICENSE file that was distributed with this source code.
  */
 
-use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class SystemEnvironmentBuilderFacade
@@ -34,6 +34,10 @@ class SystemEnvironmentBuilderFacade
      */
     public function isFunctionDisabled($function): bool
     {
-        return SystemEnvironmentBuilder::isFunctionDisabled($function);
+        $disabledFunctions = GeneralUtility::trimExplode(',', (string)ini_get('disable_functions'));
+        if (!empty($disabledFunctions)) {
+            return in_array($function, $disabledFunctions, true);
+        }
+        return false;
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First make sure you match the requirements:
 
 | Requirement | Version |
 | --- | --- |
-| TYPO3 | \>=8.7 <9.6 |
+| TYPO3 | \>=9.5 <10.5 |
 | php | \>= 7.0 |
 
 ### Composer

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We assume that the web document root (`PATH_site`) is `/var/www/html`.
 | MyVersion | /var/www/html/MyVersion |
 | typo3conf/ | /var/www/html/typo3conf/VERSION |
 | ./My/Custom/Version/File/In/Some/Nested/File/Structure | /var/www/html/./My/Custom/Version/File/In/Some/Nested/File/Structure|
+| ../ | /var/www/VERSION|
 
 ### GIT
 Since release 0.3.0 git is supported. This must be manually activated. In order to use git, make sure it's available!

--- a/Tests/Unit/Service/ProjectVersionServiceTest.php
+++ b/Tests/Unit/Service/ProjectVersionServiceTest.php
@@ -337,7 +337,7 @@ class ProjectVersionServiceTest extends UnitTestCase
 
     protected function setUpExtensionConfiguration()
     {
-        $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['project_version'] = serialize($this->extensionConfiguration);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['project_version'] = $this->extensionConfiguration;
 
         GeneralUtility::makeInstance(ExtensionConfiguration::class);
     }

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "kamiyang/project_version": "self.version"
   },
   "require": {
-    "typo3/cms-backend": "9.5.*",
-    "typo3/cms-extbase": "9.5.*",
-    "typo3/cms-extensionmanager": "9.5.*"
+    "typo3/cms-backend": "^9.5.0 || ^10.4.0",
+    "typo3/cms-extbase": "^9.5.0 || ^10.4.0",
+    "typo3/cms-extensionmanager": "^9.5.0 || ^10.4.0"
   },
   "require-dev": {
-    "nimut/testing-framework": "~4.1.1",
-    "phpunit/phpunit": "~6.5",
+    "nimut/testing-framework": "^4.1.1 || ^5.2.0",
+    "phpunit/phpunit": "^6.5",
     "satooshi/php-coveralls": "^2.0"
   },
   "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,8 +13,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.0-dev',
     'constraints' => [
         'depends' => [
-            'php' => '7.0',
-            'typo3' => '9.5.0-9.5.99'
+            'php' => '^7.0',
+            'typo3' => '9.5.0-10.4.99'
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
Changes should still be backwards compatible with v9.5, as the new "EXTENSIONS" array was introduced with v9.

However I've only tested that with TYPO3 v10